### PR TITLE
Correcting several issues with tsp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
+# Directories containing binary build artifacts
 bin
 build
 lib
+
+# Documentation build artifacts
 docs/_build
 docs/doxygen
+
+# ctags index file from running "ctags -R"
+tags

--- a/libtsp/opents.f
+++ b/libtsp/opents.f
@@ -119,28 +119,28 @@ C
 C       UNIX version
 
         open(unit=l1, 
-     &       status='scratch', 
+     &       status=type_open, 
      &       access='direct', 
 c    &       disp='delete',       
-     &       form='unformatted')
+     &       form='unformatted',
 c    &       recordtype='fixed',                       
-C    &       recordsize=4*4000)
+     &       recl=4*4000,
 c    &       organization='relative',                      
-c    &       file = 'stab.scr01')
+     &       file = 'scratch1')
 
       else
 
 c       VAX VMS version
 
         open(unit=l1, 
-     &       status='scratch', 
+     &       status=type_open, 
      &       access='direct', 
 c    &       disp='delete',       
-     &       form='unformatted') 
+     &       form='unformatted', 
 c    &       recordtype='variable',                    
-c    &       recordsize=4*4000) 
+     &       recl=4*4000, 
 c    &       organization='relative',
-c    &       file = 'scratch.dat')                                
+     &       file = 'scratch1')                                
 
 
       endif
@@ -152,14 +152,14 @@ C
 C       UNIX version
 
         open(unit=l2, 
-     &       status='scratch', 
+     &       status=type_open, 
      &       access='direct', 
 c    &       disp='delete',       
-     &       form='unformatted') 
-c    &       recordsize=4*4065) 
+     &       form='unformatted', 
+     &       recl=4*4065, 
 c    &       recordtype='fixed',       
 c    &       organization='relative', 
-c    &       file = 'stab.scr02')                                        
+     &       file = 'scratch2')                                        
 
       else
 
@@ -167,14 +167,14 @@ c       VAX VMS version
 c
 
         open(unit=l2,
-     &       status='scratch',
+     &       status=type_open,
      &       access='direct',
 c    &       disp='delete',       
-     &       form='unformatted')
-c    &       recordsize=4*4065)
+     &       form='unformatted',
+     &       recl=4*4065,
 c    &       recordtype='variable',    
 c    &       organization='relative', 
-c    &       file = 'junk.dat')                                  
+     &       file = 'scratch2')                                  
 
       endif
       return                                                            

--- a/libtsp/tspinc/params.inc
+++ b/libtsp/tspinc/params.inc
@@ -13,7 +13,7 @@ c     -
      &        MXPOOL, MAXMAC, GOVSLOTS, TURBSLOTS, MAXCV, CVSLOTS,
      &        HCCVS
       parameter (MAXBUS    = 13000)
-      parameter (MAXGEN    = MAXBUS*3/20)
+      parameter (MAXGEN    = MAXBUS/10)
       parameter (MAXBRN    = MAXBUS*5/2)
       parameter (MAXWRK    = MAXBUS/5)
       parameter (MXLSFR    = 50)

--- a/tsp/CMakeLists.txt
+++ b/tsp/CMakeLists.txt
@@ -6,7 +6,7 @@ SET(TSP_src ${SRCTSP}/main_tsp.c
 # Define the executable in terms of the source files
 ADD_EXECUTABLE(${TSPEXE} ${TSP_src})
 
-TARGET_LINK_LIBRARIES(${TSPEXE} ${TSPLIB} ${IPFLIB} ${IPFUTILLIB})
+TARGET_LINK_LIBRARIES(${TSPEXE} ${TSPLIB} ${IPFLIB})
 
 IF(WIN32)
     SET(CMAKE_INSTALL_PREFIX "C:\\Program Files")


### PR DESCRIPTION
While debugging segmentation fault that occurs when running "tsp bench.fil",
noticed that file open args were incorrect for the scratch files. Also, sizing
for max number of generators didn't match what was defined in bpf. Added git
ignore for ctags and removed unused part of tsp CMakeLists.txt.